### PR TITLE
fix(android): harden app data and cleartext defaults

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,9 @@
 
     <application
         android:name=".App"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
@@ -50,7 +52,6 @@
                 <data android:mimeType="text/x-toml" />
                 <data android:mimeType="text/plain" />
                 <data android:scheme="content" />
-                <data android:scheme="file" />
                 <data android:pathPattern=".*\\.toml" />
             </intent-filter>
         </activity>

--- a/android/app/src/main/java/com/masterdns/vpn/ui/home/HomeStatusCards.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/home/HomeStatusCards.kt
@@ -157,7 +157,7 @@ fun MdvConnectionTelemetryCard(
                 }
                 if (socksPass.isNotBlank()) {
                     Text(
-                        text = stringResource(R.string.home_socks_password, socksPass),
+                        text = stringResource(R.string.home_socks_password_hidden),
                         style = MaterialTheme.typography.bodySmall,
                         color = MdvColor.OnSurfaceVariant
                     )

--- a/android/app/src/main/java/com/masterdns/vpn/util/VpnManager.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/util/VpnManager.kt
@@ -78,6 +78,13 @@ object VpnManager {
     private var trafficMonitorJob: Job? = null
 
     private const val MAX_LOG_LINES = 500
+    private const val REDACTED_VALUE = "<redacted>"
+    private val SENSITIVE_ASSIGNMENT_REGEX = Regex(
+        "(?i)\\b(ENCRYPTION_KEY|SOCKS5_PASS|SOCKS5_USER|PASSWORD|PASS|TOKEN|SECRET)\\b\\s*[:=]\\s*(\"[^\"]*\"|'[^']*'|[^\\s,;]+)"
+    )
+    private val ANDROID_APP_PATH_REGEX = Regex(
+        "(?:/data/(?:user|data)/\\d*/?[^\\s,;]+|/data/data/[^\\s,;]+|[A-Za-z]:\\\\Users\\\\[^\\s,;]+)"
+    )
 
     fun updateState(newState: VpnState) {
         _state.value = newState
@@ -108,7 +115,7 @@ object VpnManager {
     }
 
     private fun appendLogInternal(line: String, source: LogSource) {
-        val normalizedLine = normalizeLogTimestampToLocal(line)
+        val normalizedLine = redactSensitiveLogContent(normalizeLogTimestampToLocal(line))
         val upper = normalizedLine.uppercase()
         val isError = upper.contains("[ERROR]") || upper.contains(" ERROR ")
         val isWarn = upper.contains("[WARN]") || upper.contains(" WARNING ") || upper.contains(" WARN ")
@@ -125,6 +132,14 @@ object VpnManager {
         _logEntries.value = current
         _logs.value = current.map { it.line }
         parseScanLine(normalizedLine)
+    }
+
+    private fun redactSensitiveLogContent(line: String): String {
+        return line
+            .replace(SENSITIVE_ASSIGNMENT_REGEX) { match ->
+                "${match.groupValues[1]}=$REDACTED_VALUE"
+            }
+            .replace(ANDROID_APP_PATH_REGEX, "<app-path>")
     }
 
     fun clearLogs() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="home_socks_auth_title">SOCKS5 authentication</string>
     <string name="home_socks_username">Username: %1$s</string>
     <string name="home_socks_password">Password: %1$s</string>
+    <string name="home_socks_password_hidden">Password: hidden</string>
     <string name="home_profile_title">PROFILE</string>
     <string name="home_connect">Connect</string>
     <string name="home_disconnect">Disconnect</string>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="external" path="." />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="external" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
Disable Android backup for sensitive VPN profile data and add explicit backup/data extraction exclusions for app databases, preferences, files, and external app storage.

Deny cleartext traffic by default, remove file-scheme TOML imports from the exported import activity, and avoid showing SOCKS passwords in the Home telemetry card.