### PR TITLE
perf(android): lazy-load split tunnel app list

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/ui/settings/GlobalSettingsScreen.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/settings/GlobalSettingsScreen.kt
@@ -239,6 +239,7 @@ fun GlobalSettingsScreen(vm: GlobalSettingsViewModel = viewModel()) {
                                     availableQuery = ""
                                     selectedQuery = ""
                                     activeTab = "AVAILABLE"
+                                    vm.loadInstalledAppsIfNeeded()
                                     showAppPicker = true
                                 },
                                 modifier = Modifier.fillMaxWidth()

--- a/android/app/src/main/java/com/masterdns/vpn/ui/settings/GlobalSettingsViewModel.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/settings/GlobalSettingsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.masterdns.vpn.util.GlobalSettings
 import com.masterdns.vpn.util.GlobalSettingsStore
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,10 +29,8 @@ class GlobalSettingsViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _installedApps = MutableStateFlow<List<AppEntry>>(emptyList())
     val installedApps: StateFlow<List<AppEntry>> = _installedApps
-
-    init {
-        loadInstalledApps()
-    }
+    private var installedAppsJob: Job? = null
+    private var installedAppsLoaded = false
 
     fun save(settings: GlobalSettings) {
         viewModelScope.launch {
@@ -39,8 +38,9 @@ class GlobalSettingsViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    private fun loadInstalledApps() {
-        viewModelScope.launch {
+    fun loadInstalledAppsIfNeeded() {
+        if (installedAppsLoaded || installedAppsJob?.isActive == true) return
+        installedAppsJob = viewModelScope.launch {
             val appList = withContext(Dispatchers.IO) {
                 val packageManager = getApplication<Application>().packageManager
                 val launcherIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
@@ -69,6 +69,7 @@ class GlobalSettingsViewModel(app: Application) : AndroidViewModel(app) {
                     .toList()
             }
             _installedApps.value = appList
+            installedAppsLoaded = true
         }
     }
 }


### PR DESCRIPTION
- Avoid scanning installed launcher apps when Global Settings opens.
- The app list now loads on demand when the split-tunnel picker is opened, with duplicate-load protection in the ViewModel.