### PR TITLE
fix(android): confirm profile deletion

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/ui/profiles/ProfilesScreen.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/profiles/ProfilesScreen.kt
@@ -50,6 +50,7 @@ fun ProfilesScreen(
     var editingProfile by remember { mutableStateOf<ProfileEntity?>(null) }
     var importedDraft by remember { mutableStateOf<ImportedProfileDraft?>(null) }
     var importedResolvers by remember { mutableStateOf<String?>(null) }
+    var profilePendingDelete by remember { mutableStateOf<ProfileEntity?>(null) }
     val context = androidx.compose.ui.platform.LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -195,11 +196,41 @@ fun ProfilesScreen(
                             editingProfile = profile
                             showEditor = true
                         },
-                        onDelete = { viewModel.deleteProfile(profile) }
+                        onDelete = { profilePendingDelete = profile }
                     )
                 }
             }
         }
+    }
+
+    profilePendingDelete?.let { profile ->
+        AlertDialog(
+            onDismissRequest = { profilePendingDelete = null },
+            title = { Text(stringResource(R.string.profiles_delete_confirm_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.profiles_delete_confirm_message,
+                        profile.name.ifBlank { stringResource(R.string.profiles_dialog_new_title) }
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteProfile(profile)
+                        profilePendingDelete = null
+                    }
+                ) {
+                    Text(stringResource(R.string.profiles_delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { profilePendingDelete = null }) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+            }
+        )
     }
 }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -78,6 +78,8 @@
     <string name="profiles_edit">Edit</string>
     <string name="profiles_settings">Settings</string>
     <string name="profiles_delete">Delete</string>
+    <string name="profiles_delete_confirm_title">Delete profile?</string>
+    <string name="profiles_delete_confirm_message">Delete "%1$s"? This cannot be undone.</string>
     <string name="profiles_dialog_edit_title">Edit Profile</string>
     <string name="profiles_dialog_new_title">New Profile</string>
     <string name="profiles_name">Profile Name</string>


### PR DESCRIPTION
Require an explicit confirmation dialog before deleting a profile from the Profiles screen. The existing delete flow remains unchanged after confirmation, but accidental one-tap deletes are prevented.