### PR TITLE
fix(android): harden privacy defaults

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
 
     <application
         android:name=".App"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
## Summary
- disable Android cloud/device backup for app-local profile and credential data
- deny cleartext traffic by default for Android framework networking

## Validation
- `git diff --check upstream/main..android-privacy-defaults`
- `gradle :app:compileDebugKotlin` was run in this batch and reaches Kotlin compilation, but remains blocked by the existing missing gomobile/mobile package AAR setup.