### PR TITLE
fix(android): redact sensitive runtime logs

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/util/SecretRedactor.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/util/SecretRedactor.kt
@@ -1,0 +1,47 @@
+package com.masterdns.vpn.util
+
+object SecretRedactor {
+    private const val REDACTED = "<redacted>"
+    private const val APP_PRIVATE_PATH = "<app-private-path>"
+
+    private val keyValuePattern = Regex(
+        """\b(ENCRYPTION_KEY|SOCKS5_PASS|SOCKS5_USER|SOCKS_PASSWORD|PROXY_PASSWORD|PASSWORD|SECRET|TOKEN)\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,;]+)""",
+        RegexOption.IGNORE_CASE
+    )
+    private val jsonKeyValuePattern = Regex(
+        """"(encryptionKey|socks5Pass|socksPassword|password|secret|token)"\s*:\s*("[^"]*"|[^\s,}]+)""",
+        RegexOption.IGNORE_CASE
+    )
+    private val profileLinkPattern = Regex(
+        """\b(masterdnsvpn|masterdns)://[^\s]+""",
+        RegexOption.IGNORE_CASE
+    )
+    private val appPrivatePathPattern = Regex(
+        """(?:/data/(?:user/\d+|data)/com\.masterdns\.vpn|/storage/emulated/\d+/Android/data/com\.masterdns\.vpn|/sdcard/Android/data/com\.masterdns\.vpn)(/[^\s]*)?"""
+    )
+
+    fun redact(message: String): String {
+        var redacted = message
+        redacted = profileLinkPattern.replace(redacted) { "${it.groupValues[1]}://$REDACTED" }
+        redacted = keyValuePattern.replace(redacted) {
+            "${it.groupValues[1]}=${redactedValue(it.groupValues[2])}"
+        }
+        redacted = jsonKeyValuePattern.replace(redacted) {
+            "\"${it.groupValues[1]}\": ${redactedValue(it.groupValues[2])}"
+        }
+        redacted = appPrivatePathPattern.replace(redacted) {
+            val suffix = it.groupValues.getOrNull(1).orEmpty()
+            val filename = suffix.substringAfterLast('/', missingDelimiterValue = "")
+            if (filename.isBlank()) APP_PRIVATE_PATH else "$APP_PRIVATE_PATH/$filename"
+        }
+        return redacted
+    }
+
+    private fun redactedValue(original: String): String {
+        return when {
+            original.startsWith("\"") -> "\"$REDACTED\""
+            original.startsWith("'") -> "'$REDACTED'"
+            else -> REDACTED
+        }
+    }
+}

--- a/android/app/src/main/java/com/masterdns/vpn/util/VpnManager.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/util/VpnManager.kt
@@ -176,7 +176,7 @@ object VpnManager {
     }
 
     private fun appendLogInternal(line: String, source: LogSource) {
-        val normalizedLine = normalizeLogTimestampToLocal(line)
+        val normalizedLine = SecretRedactor.redact(normalizeLogTimestampToLocal(line))
         val upper = normalizedLine.uppercase()
         val isError = upper.contains("[ERROR]") || upper.contains(" ERROR ")
         val isWarn = upper.contains("[WARN]") || upper.contains(" WARNING ") || upper.contains(" WARN ")


### PR DESCRIPTION
## Summary
- add a shared SecretRedactor for UI/runtime log lines
- redact encryption keys, SOCKS/proxy credentials, profile links, tokens, and app-private paths
- apply redaction at the VpnManager log ingestion boundary so shared logs stay safer

## Validation
- `git diff --check upstream/main..android-log-redaction`
- `gradle :app:compileDebugKotlin` reaches Kotlin compilation but is blocked by the existing missing gomobile/mobile package AAR setup, not by the redaction changes.