### PR TITLE
fix(android): surface ipv6 vpn limitation

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/ui/home/HomeStatusCards.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/home/HomeStatusCards.kt
@@ -67,6 +67,14 @@ fun MdvConnectionTelemetryCard(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MdvColor.OnSurface
             )
+            if (vpnState == VpnManager.VpnState.CONNECTED || vpnState == VpnManager.VpnState.CONNECTING) {
+                androidx.compose.foundation.layout.Spacer(modifier = Modifier.height(MdvSpace.S1))
+                Text(
+                    text = stringResource(R.string.home_ipv6_limit_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MdvColor.Error
+                )
+            }
 
             if (scanStatus.lastResolver.isNotBlank()) {
                 androidx.compose.foundation.layout.Spacer(modifier = Modifier.height(MdvSpace.S1))

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="home_connection_running">Connected and running</string>
     <string name="home_connection_preparing">Preparing tunnel (tap again to cancel)</string>
     <string name="home_connection_error_check_logs">Error - check logs</string>
+    <string name="home_ipv6_limit_warning">Android VPN mode currently routes IPv4 only. IPv6 traffic is not routed by this app path.</string>
     <string name="home_resolver_row">Resolver: %1$s  %2$s</string>
     <string name="home_valid_prefix">Valid: </string>
     <string name="home_rejected_prefix">   Rejected: </string>


### PR DESCRIPTION
## Summary
- show an in-app warning while VPN mode is active or preparing that the current Android VPN path routes IPv4 only
- keep VPN routing behavior unchanged and simply make the existing service log visible to users

## Validation
- `git diff --check`
- `gradle :app:compileDebugKotlin` reaches Kotlin compilation but is blocked by the existing missing gomobile `mobile` package/AAR setup.