### PR TITLE
fix(android): limit imported profile payloads

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/MainActivity.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/MainActivity.kt
@@ -19,7 +19,14 @@ import com.masterdns.vpn.ui.navigation.AppNavigation
 import com.masterdns.vpn.ui.theme.MasterDnsVPNTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
+
+private const val MAX_TOML_IMPORT_CHARS = 256 * 1024
+private const val MAX_PROFILE_NAME_LENGTH = 80
+private const val MAX_DOMAIN_LENGTH = 253
+private const val MAX_ENCRYPTION_KEY_LENGTH = 4096
+private const val MAX_ADVANCED_VALUE_LENGTH = 4096
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -74,7 +81,16 @@ class MainActivity : ComponentActivity() {
         }
 
         lifecycleScope.launch {
-            val content = readTextFromUri(uri)
+            val content = try {
+                readTextFromUri(uri, MAX_TOML_IMPORT_CHARS)
+            } catch (_: IOException) {
+                Toast.makeText(
+                    this@MainActivity,
+                    getString(R.string.profiles_toml_too_large_msg),
+                    Toast.LENGTH_LONG
+                ).show()
+                return@launch
+            }
             if (content.isBlank()) {
                 Toast.makeText(
                     this@MainActivity,
@@ -103,25 +119,48 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun readTextFromUri(uri: Uri): String {
+    private fun readTextFromUri(uri: Uri, maxChars: Int): String {
         return contentResolver.openInputStream(uri)?.use { stream ->
-            stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            stream.bufferedReader(Charsets.UTF_8).use { reader ->
+                val buffer = CharArray(8192)
+                val out = StringBuilder()
+                while (true) {
+                    val read = reader.read(buffer)
+                    if (read == -1) break
+                    if (out.length + read > maxChars) {
+                        throw IOException("Import file is too large")
+                    }
+                    out.append(buffer, 0, read)
+                }
+                out.toString()
+            }
         }.orEmpty()
     }
 
     private fun parseImportedProfile(uri: Uri, tomlContent: String): ProfileEntity? {
         val values = parseTomlValues(tomlContent)
         val parsedDomain = values["DOMAINS"]?.takeIf { it.isNotBlank() } ?: values["DOMAIN"]?.takeIf { it.isNotBlank() } ?: return null
-        val parsedKey = values["ENCRYPTION_KEY"]?.takeIf { it.isNotBlank() } ?: return null
-        val domainList = parsedDomain.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        val parsedKey = values["ENCRYPTION_KEY"]
+            ?.trim()
+            ?.takeIf { it.isNotBlank() && it.length <= MAX_ENCRYPTION_KEY_LENGTH }
+            ?: return null
+        val domainList = parsedDomain
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && it.length <= MAX_DOMAIN_LENGTH }
         if (domainList.isEmpty()) return null
 
         val advanced = mutableMapOf<String, String>()
         IMPORT_ADVANCED_KEYS.forEach { key ->
-            values[key]?.let { advanced[key] = it.trim() }
+            values[key]
+                ?.trim()
+                ?.takeIf { it.length <= MAX_ADVANCED_VALUE_LENGTH }
+                ?.let { advanced[key] = it }
         }
 
-        val fileName = readDisplayName(uri) ?: "Imported Profile"
+        val fileName = readDisplayName(uri)
+            ?.take(MAX_PROFILE_NAME_LENGTH)
+            ?: "Imported Profile"
 
         return ProfileEntity(
             name = fileName,

--- a/android/app/src/main/java/com/masterdns/vpn/ui/profiles/ProfilesScreen.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/profiles/ProfilesScreen.kt
@@ -37,6 +37,14 @@ import com.masterdns.vpn.util.ResolverImportStats
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.IOException
+
+private const val MAX_TOML_IMPORT_CHARS = 256 * 1024
+private const val MAX_RESOLVER_IMPORT_CHARS = ResolverAnalyzer.MAX_IMPORT_BYTES
+private const val MAX_PROFILE_NAME_LENGTH = 80
+private const val MAX_DOMAIN_LENGTH = 253
+private const val MAX_ENCRYPTION_KEY_LENGTH = 4096
+private const val MAX_ADVANCED_VALUE_LENGTH = 4096
 
 private data class ImportedProfileDraft(
     val profile: ProfileEntity,
@@ -63,7 +71,12 @@ fun ProfilesScreen(
         ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
-        val text = readTextFromUri(context, uri)
+        val text = try {
+            readTextFromUri(context, uri, MAX_TOML_IMPORT_CHARS)
+        } catch (_: IOException) {
+            scope.launch { snackbarHostState.showSnackbar(context.getString(R.string.profiles_toml_too_large_msg)) }
+            return@rememberLauncherForActivityResult
+        }
         val draft = parseProfileTomlForImport(
             fileName = readDisplayName(context, uri) ?: context.getString(R.string.profiles_imported_profile_default),
             tomlContent = text
@@ -83,7 +96,14 @@ fun ProfilesScreen(
         if (uri == null) return@rememberLauncherForActivityResult
         scope.launch {
             val fileName = readDisplayName(context, uri) ?: "client_resolvers.txt"
-            val text = withContext(Dispatchers.IO) { readTextFromUri(context, uri) }
+            val text = try {
+                withContext(Dispatchers.IO) {
+                    readTextFromUri(context, uri, MAX_RESOLVER_IMPORT_CHARS)
+                }
+            } catch (_: IOException) {
+                snackbarHostState.showSnackbar(context.getString(R.string.profiles_resolvers_too_large_msg))
+                return@launch
+            }
             val result = withContext(Dispatchers.Default) {
                 ResolverAnalyzer.analyzeAndNormalize(text, fileName)
             }
@@ -687,8 +707,20 @@ private fun ResolverImportStatsCard(stats: ResolverImportStats) {
 
 private val gson = Gson()
 
-private fun readTextFromUri(context: Context, uri: Uri): String {
-    return context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }.orEmpty()
+private fun readTextFromUri(context: Context, uri: Uri, maxChars: Int): String {
+    return context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { reader ->
+        val buffer = CharArray(8192)
+        val out = StringBuilder()
+        while (true) {
+            val read = reader.read(buffer)
+            if (read == -1) break
+            if (out.length + read > maxChars) {
+                throw IOException("Import file is too large")
+            }
+            out.append(buffer, 0, read)
+        }
+        out.toString()
+    }.orEmpty()
 }
 
 private fun readDisplayName(context: Context, uri: Uri): String? {
@@ -724,16 +756,29 @@ private fun parseProfileTomlForImport(fileName: String, tomlContent: String): Im
         values[key] = parsed
     }
 
-    val parsedDomain = if (parsedDomainsList.isNotEmpty()) parsedDomainsList else return null
-    val parsedKey = values["ENCRYPTION_KEY"]?.takeIf { it.isNotBlank() } ?: return null
+    val parsedDomain = if (parsedDomainsList.isNotEmpty()) {
+        parsedDomainsList
+            .map { it.trim() }
+            .filter { it.isNotBlank() && it.length <= MAX_DOMAIN_LENGTH }
+    } else {
+        return null
+    }
+    if (parsedDomain.isEmpty()) return null
+    val parsedKey = values["ENCRYPTION_KEY"]
+        ?.trim()
+        ?.takeIf { it.isNotBlank() && it.length <= MAX_ENCRYPTION_KEY_LENGTH }
+        ?: return null
 
     val advanced = mutableMapOf<String, String>()
     IMPORT_ADVANCED_KEYS.forEach { key ->
-        values[key]?.let { advanced[key] = it.trim() }
+        values[key]
+            ?.trim()
+            ?.takeIf { it.length <= MAX_ADVANCED_VALUE_LENGTH }
+            ?.let { advanced[key] = it }
     }
 
     val importedProfile = ProfileEntity(
-        name = fileName,
+        name = fileName.take(MAX_PROFILE_NAME_LENGTH),
         domains = gson.toJson(parsedDomain),
         encryptionMethod = values["DATA_ENCRYPTION_METHOD"]?.toIntOrNull() ?: 1,
         encryptionKey = parsedKey,

--- a/android/app/src/main/java/com/masterdns/vpn/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/settings/SettingsScreen.kt
@@ -77,8 +77,12 @@ import com.masterdns.vpn.util.ResolverAnalyzer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.IOException
 
 private enum class FieldType { TEXT, BOOL, OPTION }
+
+private const val MAX_TOML_IMPORT_CHARS = 256 * 1024
+private const val MAX_RESOLVER_IMPORT_CHARS = ResolverAnalyzer.MAX_IMPORT_BYTES
 
 private data class SettingField(
     val section: String,
@@ -271,7 +275,12 @@ fun SettingsScreen(
         ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri != null) {
-            val text = readTextFromUri(context, uri)
+            val text = try {
+                readTextFromUri(context, uri, MAX_TOML_IMPORT_CHARS)
+            } catch (_: IOException) {
+                scope.launch { snackbarHostState.showSnackbar(context.getString(R.string.profiles_toml_too_large_msg)) }
+                return@rememberLauncherForActivityResult
+            }
             val updated = viewModel.importTomlValues(text, fieldsState.toMap())
             fieldsState.clear()
             fieldsState.putAll(updated)
@@ -284,9 +293,16 @@ fun SettingsScreen(
     ) { uri ->
         val selected = profile
         if (uri != null && selected != null) {
-            val text = readTextFromUri(context, uri)
-            val fileName = readDisplayName(context, uri) ?: "client_resolvers.txt"
             scope.launch {
+                val text = try {
+                    withContext(Dispatchers.IO) {
+                        readTextFromUri(context, uri, MAX_RESOLVER_IMPORT_CHARS)
+                    }
+                } catch (_: IOException) {
+                    snackbarHostState.showSnackbar(context.getString(R.string.profiles_resolvers_too_large_msg))
+                    return@launch
+                }
+                val fileName = readDisplayName(context, uri) ?: "client_resolvers.txt"
                 val result = withContext(Dispatchers.Default) {
                     ResolverAnalyzer.analyzeAndNormalize(text, fileName)
                 }
@@ -612,11 +628,25 @@ private fun ConfigFieldCard(
     }
 }
 
-private fun readTextFromUri(context: Context, uri: Uri): String {
+private fun readTextFromUri(context: Context, uri: Uri, maxChars: Int): String {
     return runCatching {
-        val stream = context.contentResolver.openInputStream(uri)
-        stream?.bufferedReader()?.use { it.readText() } ?: ""
-    }.getOrDefault("")
+        context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { reader ->
+            val buffer = CharArray(8192)
+            val out = StringBuilder()
+            while (true) {
+                val read = reader.read(buffer)
+                if (read == -1) break
+                if (out.length + read > maxChars) {
+                    throw IOException("Import file is too large")
+                }
+                out.append(buffer, 0, read)
+            }
+            out.toString()
+        } ?: ""
+    }.getOrElse { error ->
+        if (error is IOException) throw error
+        ""
+    }
 }
 
 private fun readDisplayName(context: Context, uri: Uri): String? {

--- a/android/app/src/main/java/com/masterdns/vpn/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/settings/SettingsViewModel.kt
@@ -17,6 +17,10 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val MAX_DOMAIN_LENGTH = 253
+private const val MAX_ENCRYPTION_KEY_LENGTH = 4096
+private const val MAX_ADVANCED_VALUE_LENGTH = 4096
+
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val profileRepository: ProfileRepository,
@@ -64,12 +68,15 @@ class SettingsViewModel @Inject constructor(
                     .removeSuffix("]")
                     .split(",")
                     .map { it.trim().removeSurrounding("\"") }
-                    .filter { it.isNotBlank() }
+                    .filter { it.isNotBlank() && it.length <= MAX_DOMAIN_LENGTH }
                     .joinToString(", ")
                 valueRaw.startsWith("\"") && valueRaw.endsWith("\"") ->
                     valueRaw.removeSurrounding("\"")
                 else -> valueRaw
             }
+            if (parsed.isBlank()) return@forEach
+            if (key == "ENCRYPTION_KEY" && parsed.length > MAX_ENCRYPTION_KEY_LENGTH) return@forEach
+            if (key in ADVANCED_SETTING_KEYS && parsed.length > MAX_ADVANCED_VALUE_LENGTH) return@forEach
             result[key] = parsed
         }
         return result

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="profiles_resolvers_empty_msg">Resolvers file is empty</string>
     <string name="profiles_resolvers_imported_msg">Resolvers imported into profile form</string>
     <string name="profiles_resolvers_imported_stats_msg">Resolvers imported: %1$s</string>
+    <string name="profiles_toml_too_large_msg">TOML import is too large.</string>
+    <string name="profiles_resolvers_too_large_msg">Resolvers file is too large.</string>
     <string name="profiles_resolvers_import_preview_title">Resolver import preview</string>
     <string name="profiles_resolvers_import_preview_body">%1$d usable, %2$d duplicate, %3$d invalid, %4$d CIDR ranges</string>
     <string name="profiles_resolvers_import_preview_limits">Large CIDR ranges skipped: %1$d. Import may be capped for stability.</string>


### PR DESCRIPTION
## Summary
- cap TOML import reads at 256 KiB before loading file contents into memory
- cap resolver import reads at the existing resolver analyzer limit before normalization
- skip overlong imported domains, encryption keys, and advanced values with clear too-large messages

## Validation
- `git diff --check`
- `gradle :app:compileDebugKotlin` reaches Kotlin compilation but is blocked by the existing missing gomobile `mobile` package/AAR setup.