### PR TITLE
feat(android): improve sharing credential actions

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/ui/settings/GlobalSettingsScreen.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/ui/settings/GlobalSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.masterdns.vpn.ui.settings
 
+import android.util.Base64
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
@@ -25,6 +26,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -82,6 +85,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.compose.runtime.LaunchedEffect
 import java.net.InetAddress
+import java.security.SecureRandom
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -113,6 +117,20 @@ fun GlobalSettingsScreen(vm: GlobalSettingsViewModel = viewModel()) {
     val splitPackagesCount by remember(draft.splitPackagesCsv) {
         derivedStateOf { parseCsv(draft.splitPackagesCsv).size }
     }
+    fun rotateSharingPassword() {
+        draft = draft.copy(
+            internetSharingUser = draft.internetSharingUser.ifBlank { "masterdns" },
+            internetSharingPass = generateSharingPassword()
+        )
+    }
+
+    fun generateSharingCredentials() {
+        draft = draft.copy(
+            internetSharingUser = "masterdns",
+            internetSharingPass = generateSharingPassword()
+        )
+    }
+
     fun saveGlobalSettings() {
         if (socksPortMissing || httpPortMissing) {
             scope.launch {
@@ -342,6 +360,24 @@ fun GlobalSettingsScreen(vm: GlobalSettingsViewModel = viewModel()) {
                                     fontWeight = FontWeight.Medium,
                                     color = MdvColor.PrimaryContainer
                                 )
+                                Text(
+                                    stringResource(
+                                        R.string.global_sharing_socks_endpoint,
+                                        localIp,
+                                        sharingSocksPortText.ifBlank { "?" }
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MdvColor.OnSurfaceVariant
+                                )
+                                Text(
+                                    stringResource(
+                                        R.string.global_sharing_http_endpoint,
+                                        localIp,
+                                        sharingHttpPortText.ifBlank { "?" }
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MdvColor.OnSurfaceVariant
+                                )
                             }
                             Text(
                                 stringResource(R.string.global_sharing_lan_warning),
@@ -415,6 +451,28 @@ fun GlobalSettingsScreen(vm: GlobalSettingsViewModel = viewModel()) {
                                 visualTransformation = PasswordVisualTransformation(),
                                 modifier = Modifier.fillMaxWidth()
                             )
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                OutlinedButton(
+                                    onClick = ::generateSharingCredentials,
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Icon(Icons.Filled.Key, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(stringResource(R.string.global_generate_credentials))
+                                }
+                                OutlinedButton(
+                                    onClick = ::rotateSharingPassword,
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(stringResource(R.string.global_rotate_password))
+                                }
+                            }
 
                             Text(
                                 stringResource(R.string.global_sharing_help),
@@ -727,6 +785,12 @@ private fun isValidIpLiteral(value: String): Boolean {
     }
     if (!numericCandidate) return false
     return runCatching { InetAddress.getByName(text) }.isSuccess
+}
+
+private fun generateSharingPassword(): String {
+    val bytes = ByteArray(18)
+    SecureRandom().nextBytes(bytes)
+    return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
 }
 
 private fun getSystemLocalIp(): String? {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -144,6 +144,10 @@
     <string name="global_http_port_required">HTTP port is required.</string>
     <string name="global_username">Username</string>
     <string name="global_password">Password</string>
+    <string name="global_generate_credentials">Generate</string>
+    <string name="global_rotate_password">Rotate</string>
+    <string name="global_sharing_socks_endpoint">SOCKS5: %1$s:%2$s</string>
+    <string name="global_sharing_http_endpoint">HTTP: %1$s:%2$s</string>
     <string name="global_sharing_lan_warning">Sharing listens on your local network. Use a username and password before enabling it.</string>
     <string name="global_sharing_help">Use these endpoints to share your VPN connection with other devices or apps on the same network.</string>
     <string name="info_app_name_title">MasterDnsVPN</string>


### PR DESCRIPTION
## Summary
- add generate and rotate actions for internet sharing credentials
- show concrete SOCKS5 and HTTP LAN endpoints when sharing is enabled
- keep existing blocking validation for empty sharing credentials

## Validation
- `git diff --check`
- `gradle :app:compileDebugKotlin` reaches Kotlin compilation but is blocked by the existing missing gomobile `mobile` package/AAR setup.