### PR TITLE
chore: gitignore Android AAR, keystore, and Gradle caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,11 @@ logs/
 build/
 .gocache
 .bench/
+# Android build artifacts and signing keys
+*.aar
+*.jks
+*.keystore
+android/.gradle/
+android/local.properties
+android/release.jks
+android/app/libs/*.aar


### PR DESCRIPTION
### Why

- `android/build_go_mobile.sh` produces `android/app/libs/masterdnsvpn.aar` — if staged, it bloats the repo
- `.github/workflows/release-manual.yml` writes `android/release.jks` (the signing keystore) — staging it leaks the **private signing key**
- `android/.gradle/` and `android/local.properties` are local Gradle/SDK state that vary per machine

### Verification

All entries confirmed via `git check-ignore -v`:
- `android/app/libs/masterdnsvpn.aar` → `.gitignore:33` (wildcard `android/app/libs/*.aar`)
- `android/release.jks` → `.gitignore:32` (explicit path)
- `android/.gradle/test` → `.gitignore:30` (wildcard `android/.gradle/`)
- `android/local.properties` → `.gitignore:31` (explicit path)

Scope: `.gitignore` only — no other files modified