### PR TITLE
fix(vpn): IPv6 CONNECT parse, native Int port storage, malformed-intent guard (#019)

### DIFF
--- a/android/app/src/main/java/com/masterdns/vpn/service/MasterDnsVpnService.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/service/MasterDnsVpnService.kt
@@ -60,7 +60,25 @@ class MasterDnsVpnService : VpnService() {
             "com.android.chrome" // system Chrome on some OEMs
         )
 
-
+        internal fun parseConnectTarget(url: String): Pair<String, Int> {
+            if (url.startsWith("[")) {
+                val close = url.indexOf("]")
+                if (close > 0) {
+                    val host = url.substring(1, close)
+                    val portPart = url.substring(close + 1).removePrefix(":")
+                    val port = portPart.toIntOrNull()?.coerceIn(1, 65535) ?: 80
+                    return host to port
+                }
+            }
+            val lastColon = url.lastIndexOf(':')
+            return if (lastColon > 0) {
+                val host = url.substring(0, lastColon)
+                val port = url.substring(lastColon + 1).toIntOrNull()?.coerceIn(1, 65535) ?: 80
+                host to port
+            } else {
+                url to 80
+            }
+        }
     }
 
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -979,9 +997,7 @@ class MasterDnsVpnService : VpnService() {
             }
 
             if (method == "CONNECT") {
-                val hostPort = url.split(":")
-                val host = hostPort[0]
-                val port = hostPort.getOrElse(1) { "80" }.toIntOrNull() ?: 80
+                val (host, port) = parseConnectTarget(url)
 
                 output.write("HTTP/1.1 200 Connection Established\r\n\r\n")
                 output.flush()

--- a/android/app/src/main/java/com/masterdns/vpn/service/MasterDnsVpnService.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/service/MasterDnsVpnService.kt
@@ -140,6 +140,19 @@ class MasterDnsVpnService : VpnService() {
                 val profileId = intent.getLongExtra(EXTRA_PROFILE_ID, -1)
                 if (profileId > 0) {
                     startVpn(profileId)
+                } else {
+                    val msg = "Invalid profile id: $profileId"
+                    VpnManager.appendLog(msg)
+                    VpnManager.setError(msg)
+                    runCatching {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                            stopForeground(STOP_FOREGROUND_REMOVE)
+                        } else {
+                            @Suppress("DEPRECATION")
+                            stopForeground(true)
+                        }
+                    }
+                    runCatching { stopSelf() }
                 }
             }
             ACTION_DISCONNECT -> {

--- a/android/app/src/main/java/com/masterdns/vpn/util/GlobalSettingsStore.kt
+++ b/android/app/src/main/java/com/masterdns/vpn/util/GlobalSettingsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -38,8 +39,8 @@ object GlobalSettingsStore {
     private val KEY_CUSTOM_DNS_SERVERS = stringPreferencesKey("custom_dns_servers")
     private val KEY_FAKE_DNS_ENABLED = booleanPreferencesKey("fake_dns_enabled")
     private val KEY_INTERNET_SHARING_ENABLED = booleanPreferencesKey("internet_sharing_enabled")
-    private val KEY_INTERNET_SHARING_SOCKS_PORT = stringPreferencesKey("internet_sharing_socks_port")
-    private val KEY_INTERNET_SHARING_HTTP_PORT = stringPreferencesKey("internet_sharing_http_port")
+    private val KEY_INTERNET_SHARING_SOCKS_PORT = intPreferencesKey("internet_sharing_socks_port_v2")
+    private val KEY_INTERNET_SHARING_HTTP_PORT = intPreferencesKey("internet_sharing_http_port_v2")
     private val KEY_INTERNET_SHARING_USER = stringPreferencesKey("internet_sharing_user")
     private val KEY_INTERNET_SHARING_PASS = stringPreferencesKey("internet_sharing_pass")
 
@@ -63,8 +64,8 @@ object GlobalSettingsStore {
             prefs[KEY_CUSTOM_DNS_SERVERS] = settings.customDnsServers
             prefs[KEY_FAKE_DNS_ENABLED] = settings.fakeDnsEnabled
             prefs[KEY_INTERNET_SHARING_ENABLED] = settings.internetSharingEnabled
-            prefs[KEY_INTERNET_SHARING_SOCKS_PORT] = settings.internetSharingSocksPort.toString()
-            prefs[KEY_INTERNET_SHARING_HTTP_PORT] = settings.internetSharingHttpPort.toString()
+            prefs[KEY_INTERNET_SHARING_SOCKS_PORT] = settings.internetSharingSocksPort.coerceIn(1, 65535)
+            prefs[KEY_INTERNET_SHARING_HTTP_PORT] = settings.internetSharingHttpPort.coerceIn(1, 65535)
             prefs[KEY_INTERNET_SHARING_USER] = settings.internetSharingUser
             prefs[KEY_INTERNET_SHARING_PASS] = settings.internetSharingPass
         }
@@ -80,8 +81,8 @@ object GlobalSettingsStore {
             customDnsServers = this[KEY_CUSTOM_DNS_SERVERS] ?: "",
             fakeDnsEnabled = this[KEY_FAKE_DNS_ENABLED] ?: true,
             internetSharingEnabled = this[KEY_INTERNET_SHARING_ENABLED] ?: false,
-            internetSharingSocksPort = this[KEY_INTERNET_SHARING_SOCKS_PORT]?.toIntOrNull() ?: 8090,
-            internetSharingHttpPort = this[KEY_INTERNET_SHARING_HTTP_PORT]?.toIntOrNull() ?: 8091,
+            internetSharingSocksPort = this[KEY_INTERNET_SHARING_SOCKS_PORT] ?: 8090,
+            internetSharingHttpPort = this[KEY_INTERNET_SHARING_HTTP_PORT] ?: 8091,
             internetSharingUser = this[KEY_INTERNET_SHARING_USER] ?: "",
             internetSharingPass = this[KEY_INTERNET_SHARING_PASS] ?: ""
         )

--- a/android/app/src/test/java/com/masterdns/vpn/service/MasterDnsVpnServiceConnectParseTest.kt
+++ b/android/app/src/test/java/com/masterdns/vpn/service/MasterDnsVpnServiceConnectParseTest.kt
@@ -1,0 +1,41 @@
+package com.masterdns.vpn.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MasterDnsVpnServiceConnectParseTest {
+    @Test
+    fun parsesIpv6LiteralWithPort() {
+        val (host, port) = MasterDnsVpnService.parseConnectTarget("[::1]:443")
+        assertEquals("::1", host)
+        assertEquals(443, port)
+    }
+
+    @Test
+    fun parsesIpv6LiteralWithoutPort() {
+        val (host, port) = MasterDnsVpnService.parseConnectTarget("[::1]")
+        assertEquals("::1", host)
+        assertEquals(80, port)
+    }
+
+    @Test
+    fun parsesIpv4WithPort() {
+        val (host, port) = MasterDnsVpnService.parseConnectTarget("127.0.0.1:8080")
+        assertEquals("127.0.0.1", host)
+        assertEquals(8080, port)
+    }
+
+    @Test
+    fun parsesDomainWithoutPort() {
+        val (host, port) = MasterDnsVpnService.parseConnectTarget("example.com")
+        assertEquals("example.com", host)
+        assertEquals(80, port)
+    }
+
+    @Test
+    fun coercesOutOfRangePortToClampedValue() {
+        val (host, port) = MasterDnsVpnService.parseConnectTarget("example.com:99999")
+        assertEquals("example.com", host)
+        assertEquals(65535, port)
+    }
+}


### PR DESCRIPTION
Three independent latent bugs that fail silently or with confusing
symptoms on the internet-sharing + connect paths:

* IPv6-literal HTTP CONNECT: the HTTP proxy split `CONNECT [::1]:443`
  on `:` and took `host = "["`, silently failing every IPv6-literal
  CONNECT (browser showed "connection failed" with no diagnostic).
  Replaced the inline split with a `parseConnectTarget` helper on
  MasterDnsVpnService.companion that handles bracketed IPv6 literals
  and a missing port (defaults to 80). The helper is `internal` so a
  JVM unit test can exercise it without Robolectric.

* Non-numeric / out-of-range sharing ports: GlobalSettingsStore stored
  internetSharingSocksPort/HttpPort as String and parsed with
  `toIntOrNull() ?: 8090/8091` on load. A corrupted DataStore value
  silently fell back to defaults; an out-of-range integer (e.g. 99999)
  loaded fine and threw IllegalArgumentException only when ServerSocket
  bound at connect time, surfacing as a generic "Go core error".
  Switched both keys to native intPreferencesKey, coerced to 1..65535
  on save. Existing on-device String entries are migrated cleanly by
  renaming the keys to `..._v2` (option a): old String entries are
  simply absent on first load and the 8090/8091 default re-applies —
  no Migration code, one-time settings reset for users who had set a
  non-default port (call out in release notes).

* Malformed ACTION_CONNECT: onStartCommand swallowed profileId <= 0
  with no log, no state update, no stopSelf. The service stayed in
  START_STICKY foreground with a "Connecting..." notification and
  VpnState.CONNECTING forever; the user had to force-stop the app.
  Added an else branch that calls VpnManager.appendLog + setError
  (UI already observes both), stopForeground (API-24-guarded with
  @Suppress("DEPRECATION") fallback), and stopSelf so START_STICKY
  doesn't keep the service alive with no work.

Added 5 JVM unit tests for parseConnectTarget:
  - [::1]:443 -> ("::1", 443)
  - [::1]      -> ("::1", 80)
  - 127.0.0.1:8080 -> ("127.0.0.1", 8080)
  - example.com    -> ("example.com", 80)
  - example.com:99999 -> ("example.com", 65535)  [coerceIn clamps]

No local build verified (no local Android SDK); CI on push is the
gate (android-ci.yml: debug APK + AAR).

Scope: only 3 files touched — MasterDnsVpnService.kt (+33/-3),
GlobalSettingsStore.kt (+7/-6), new test file (+41).